### PR TITLE
support simple destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Given the following configuration:
 
 ```js
 {
-  enabled: true,
   removals: [
     {
       module: 'ember',

--- a/test/fixtures/destructuring/expected.js
+++ b/test/fixtures/destructuring/expected.js
@@ -1,0 +1,14 @@
+var _Ember = Ember;
+var assert = _Ember.assert;
+var deprecate = _Ember.deprecate;
+var _Ember2 = Ember;
+var debug = _Ember2.debug;
+var _Ember3 = Ember;
+var renamedWarn = _Ember3.warn;
+var _OtherThing = OtherThing;
+var doSomething = _OtherThing.doSomething;
+
+warn('this will NOT be removed');
+info('this will NOT be removed');
+
+console.log(message);

--- a/test/fixtures/destructuring/fixture.js
+++ b/test/fixtures/destructuring/fixture.js
@@ -1,0 +1,21 @@
+const {
+  assert,
+  deprecate
+} = Ember;
+
+const { debug } = Ember;
+
+const { warn: renamedWarn } = Ember;
+
+const { doSomething } = OtherThing;
+
+deprecate('this will be removed', test);
+assert('this will be removed', test);
+debug('this will be removed');
+renamedWarn('this will be removed');
+doSomething('this will be removed');
+
+warn('this will NOT be removed');
+info('this will NOT be removed');
+
+console.log(message);

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ function testFixture(name, options) {
       plugins: [plugin(options)]
     });
 
-    assert.strictEqual(result.code.trim(), expected.trim());
+    assert.strictEqual(expected.trim(), result.code.trim());
   });
 }
 
@@ -42,6 +42,19 @@ describe('babel-plugin-remove-functions', function() {
       {
         module: 'ember',
         methods: []
+      }
+    ]
+  });
+
+  testFixture('destructuring', {
+    removals: [
+      {
+        global: 'Ember',
+        methods: ['assert', 'deprecate', 'debug', 'warn']
+      },
+      {
+        global: 'OtherThing',
+        methods: ['doSomething']
       }
     ]
   });


### PR DESCRIPTION
closes https://github.com/GavinJoyce/babel-plugin-remove-functions/issues/13

This handles destructuring cases such as:

```js
{
  removals: [ //example config
    {
      global: 'Ember',
      methods: ['assert', 'deprecate', 'debug', 'warn']
    }
  ]
}
```

```js
const { assert, deprecate } = Ember;
const { debug } = Ember;
const { warn: renamedWarn } = Ember;

deprecate('this will be removed', test);
assert('this will be removed', test);
debug('this will be removed');
renamedWarn('this will be removed');

warn('this will NOT be removed');
info('this will NOT be removed');

console.log(message);
```

which effectively leaves:

```js
warn('this will NOT be removed');
info('this will NOT be removed');

console.log(message);
```

It doesn't handle nested destructuring such as:

```js
const { run: { later }} = Ember;

later(this, function() {...}, 1000); //there is no configuration which will remove this
``` 
We could support this in future but it may not be worth the added complexity. This style of import is pretty unreadable.

