### PR TITLE
correct config

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ module.exports = function(options) {
 
       VariableDeclaration: function(node) {
         node.declarations.forEach(function(declaration) {
-          var globalImport = declaration.init.name; //eg. `Ember` (from `const { debug } = Ember;`)
+          var importName = declaration.init.name; //eg. `Ember` (from `const { debug } = Ember;`)
 
           options.removals.forEach(function(removal) {
-            if(removal.global === globalImport) {
+            if(removal.module === importName) {
               declaration.id.properties.forEach(function(property) {
                 //eg. const { warn: renamedWarn } = Ember;
                 //    =>: property.key.name => 'warn'

--- a/test/test.js
+++ b/test/test.js
@@ -49,11 +49,11 @@ describe('babel-plugin-remove-functions', function() {
   testFixture('destructuring', {
     removals: [
       {
-        global: 'Ember',
+        module: 'Ember',
         methods: ['assert', 'deprecate', 'debug', 'warn']
       },
       {
-        global: 'OtherThing',
+        module: 'OtherThing',
         methods: ['doSomething']
       }
     ]


### PR DESCRIPTION
I made a mistake with the config in https://github.com/GavinJoyce/babel-plugin-remove-functions/pull/16

**before:**

```js
{
    removals: [
      {
        global: 'Ember',
        methods: ['assert', 'deprecate', 'debug', 'warn']
      },
      {
        global: 'OtherThing',
        methods: ['doSomething']
      }
    ]
  }
```

**after:**

```js
{
    removals: [
      {
        module: 'Ember',
        methods: ['assert', 'deprecate', 'debug', 'warn']
      },
      {
        module: 'OtherThing',
        methods: ['doSomething']
      }
    ]
  }
```

